### PR TITLE
fix: correct import path for utils in resizable component

### DIFF
--- a/src/components/layout/resizable.tsx
+++ b/src/components/layout/resizable.tsx
@@ -22,7 +22,7 @@
 
 import { Panel, Group, Separator } from "react-resizable-panels";
 import type { GroupProps, SeparatorProps } from "react-resizable-panels";
-import { cn } from "../lib/utils";
+import { cn } from "../../lib/utils";
 
 const ResizablePanelGroup = ({
   className,


### PR DESCRIPTION
## Summary
- Fixes the import path for `cn` utility in the resizable component
- The path was `../lib/utils` but should be `../../lib/utils` since resizable.tsx is in `src/components/layout/` and utils.ts is in `src/lib/`

## Test plan
- [x] Build passes
- [x] No import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)