### PR TITLE
fix(dock-icon): optional-chain getBoundingClientRect

### DIFF
--- a/src/components/navigation/dock-icon.tsx
+++ b/src/components/navigation/dock-icon.tsx
@@ -81,8 +81,9 @@ const DockContainer: React.FC<DockContainerProps> = ({
     const item = itemRefs.current.get(index);
     if (!item || !containerRef.current) return 1;
 
-    const itemRect = item.getBoundingClientRect();
-    const containerRect = containerRef.current.getBoundingClientRect();
+    const itemRect = item.getBoundingClientRect?.();
+    const containerRect = containerRef.current.getBoundingClientRect?.();
+    if (!itemRect || !containerRect) return 1;
     const itemCenter = itemRect.left + itemRect.width / 2 - containerRect.left;
 
     const distance = Math.abs(mouseX - itemCenter);


### PR DESCRIPTION
Closes SKAI-Trading/skai-interface#952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds null/undefined guards around DOM measurement calls to avoid runtime errors in edge environments.
> 
> **Overview**
> Fixes `DockContainer` magnification scaling to safely handle missing `getBoundingClientRect` by optional-chaining the calls and early-returning a default scale when rects aren’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413547fbde8d04608587f32326e2e6dc53556e44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->